### PR TITLE
chore(action): bump hugo from 0.112.6 to 0.112.7

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,7 +28,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.112.6
+      HUGO_VERSION: 0.112.7
     steps:
       - name: Install Hugo CLI
         run: |


### PR DESCRIPTION
Bump [Hugo](https://github.com/gohugoio/hugo) from 0.112.6 to 0.112.7

---
Release: https://github.com/gohugoio/hugo/releases/tag/v0.112.7
Changelog: https://github.com/gohugoio/hugo/compare/v0.112.6...v0.112.7