### PR TITLE
chore(action): bump hugo from 0.115.2 to 0.115.3

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,7 +28,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.115.2
+      HUGO_VERSION: 0.115.3
     steps:
       - name: Install Hugo CLI
         run: |


### PR DESCRIPTION
Bump [Hugo](https://github.com/gohugoio/hugo) from 0.115.2 to 0.115.3

---
Release: https://github.com/gohugoio/hugo/releases/tag/v0.115.3
Changelog: https://github.com/gohugoio/hugo/compare/v0.115.2...v0.115.3