### PR TITLE
chore(action): bump hugo from 0.117.0 to 0.118.2

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,7 +28,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.117.0
+      HUGO_VERSION: 0.118.2
     steps:
       - name: Install Hugo CLI
         run: |


### PR DESCRIPTION
Bump [Hugo](https://github.com/gohugoio/hugo) from 0.117.0 to 0.118.2

---
Release: https://github.com/gohugoio/hugo/releases/tag/v0.118.2
Changelog: https://github.com/gohugoio/hugo/compare/v0.117.0...v0.118.2