### PR TITLE
chore(action): bump hugo from 0.118.2 to 0.119.0

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,7 +28,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.118.2
+      HUGO_VERSION: 0.119.0
     steps:
       - name: Install Hugo CLI
         run: |


### PR DESCRIPTION
Bump [Hugo](https://github.com/gohugoio/hugo) from 0.118.2 to 0.119.0

---
Release: https://github.com/gohugoio/hugo/releases/tag/v0.119.0
Changelog: https://github.com/gohugoio/hugo/compare/v0.118.2...v0.119.0