### PR TITLE
chore(action): bump hugo from 0.120.3 to 0.120.4

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,7 +28,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.120.3
+      HUGO_VERSION: 0.120.4
     steps:
       - name: Install Hugo CLI
         run: |


### PR DESCRIPTION
Bump [Hugo](https://github.com/gohugoio/hugo) from 0.120.3 to 0.120.4

---
Release: https://github.com/gohugoio/hugo/releases/tag/v0.120.4
Changelog: https://github.com/gohugoio/hugo/compare/v0.120.3...v0.120.4