### PR TITLE
fix(actions): revert upload-pages-artifact to v2

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,12 +8,6 @@ on:
 
   workflow_dispatch:
 
-# Permissions for the GITHUB_TOKEN required for deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
@@ -57,7 +51,7 @@ jobs:
           hugo --gc --minify --baseURL "${{ steps.pages.outputs.base_url }}/"
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v2
         with:
           path: ./public
 
@@ -67,8 +61,17 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
 
+      - run: |
+          IFS='' read -r -d '' "$GITHUB_STEP_SUMMARY" <<"EOF"
+          \## Deployment information
+
+          Url: ${{ steps.deployment.outputs.page_url }}
+          EOF


### PR DESCRIPTION
The current upload artifact with v3 doesn't seem to be correct.
Therefore revert back to v2 for the moment.
Also add an extra step to deploy job to write github job summary page.

https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/
