### PR TITLE
revert(actions): revert deploy pages to v3

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v3
 
       - run: |
           IFS='' read -r -d '' "$GITHUB_STEP_SUMMARY" <<"EOF"


### PR DESCRIPTION
The actions/deploy-pages v4 can only work with
actions/upload-pages-artifact v3 or newer.
As these causes deploy error, this version needs to be reverted.

https://github.com/actions/deploy-pages/releases/tag/v4.0.0
https://github.com/actions/upload-pages-artifact/releases/tag/v3.0.0
