### PR TITLE
chore(action): bump hugo from 0.123.7 to 0.123.8

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.123.7
+      HUGO_VERSION: 0.123.8
     steps:
       - name: Install Hugo CLI
         run: |


### PR DESCRIPTION
Bump [Hugo](https://github.com/gohugoio/hugo) from 0.123.7 to 0.123.8
---
Release: https://github.com/gohugoio/hugo/releases/tag/v0.123.8
Changelog: https://github.com/gohugoio/hugo/compare/v0.123.7...v0.123.8