### PR TITLE
chore(action): bump hugo from 0.126.1 to 0.126.3

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.126.1
+      HUGO_VERSION: 0.126.3
     steps:
       - name: Install Hugo CLI
         run: |


### PR DESCRIPTION
Bump [Hugo](https://github.com/gohugoio/hugo) from 0.126.1 to 0.126.3
---
Release: https://github.com/gohugoio/hugo/releases/tag/v0.126.3
Changelog: https://github.com/gohugoio/hugo/compare/v0.126.1...v0.126.3