### PR TITLE
chore(action): bump hugo from 0.126.3 to 0.127.0

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.126.3
+      HUGO_VERSION: 0.127.0
     steps:
       - name: Install Hugo CLI
         run: |


### PR DESCRIPTION
Bump [Hugo](https://github.com/gohugoio/hugo) from 0.126.3 to 0.127.0
---
Release: https://github.com/gohugoio/hugo/releases/tag/v0.127.0
Changelog: https://github.com/gohugoio/hugo/compare/v0.126.3...v0.127.0