### PR TITLE
chore(action): bump hugo from 0.128.0 to 0.128.2

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.128.0
+      HUGO_VERSION: 0.128.2
     steps:
       - name: Install Hugo CLI
         run: |


### PR DESCRIPTION
Bump [Hugo](https://github.com/gohugoio/hugo) from 0.128.0 to 0.128.2
---
Release: https://github.com/gohugoio/hugo/releases/tag/v0.128.2
Changelog: https://github.com/gohugoio/hugo/compare/v0.128.0...v0.128.2