### PR TITLE
chore(action): bump hugo from 0.139.2 to 0.139.3

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.139.2
+      HUGO_VERSION: 0.139.3
     steps:
       - name: Install Hugo CLI
         run: |


### PR DESCRIPTION
Bump [Hugo](https://github.com/gohugoio/hugo) from 0.139.2 to 0.139.3
---
Release: https://github.com/gohugoio/hugo/releases/tag/v0.139.3
Changelog: https://github.com/gohugoio/hugo/compare/v0.139.2...v0.139.3