### PR TITLE
fix(workflows): revert hugo from version 0.139.5 to 0.139.4

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.139.5
+      HUGO_VERSION: 0.139.4
     steps:
       - name: Install Hugo CLI
         run: |


### PR DESCRIPTION
Version `0.139.5` is just a technical release and therefore, the
previous version should be used instead.

See also:
- https://github.com/gohugoio/hugo/releases/tag/v0.139.5
- https://github.com/gohugoio/hugo/releases/tag/v0.139.4
