### PR TITLE
fix(hugo): replace resources.ToCSS with css.Sass

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -23,7 +23,7 @@
 
 <!-- CSS -->
 {{ $options := (dict "targetPath" "main.css" "outputStyle" "compressed" "enableSourceMap" true) }}
-{{ $style := resources.Get "scss/main.scss" | resources.ToCSS $options | resources.Fingerprint }}
+{{ $style := resources.Get "scss/main.scss" | css.Sass $options | resources.Fingerprint }}
 <link rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}">
 
 {{ range $val := $.Site.Params.customCSS }}


### PR DESCRIPTION
Fixed build error
```
ERROR deprecated: resources.ToCSS was deprecated in Hugo v0.128.0 and
will be removed in Hugo 0.141.0. Use css.Sass instead.
```
