### PR TITLE
chore(action): bump hugo from 0.142.0 to 0.143.0

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.142.0
+      HUGO_VERSION: 0.143.0
     steps:
       - name: Install Hugo CLI
         run: |


### PR DESCRIPTION
Bump [Hugo](https://github.com/gohugoio/hugo) from 0.142.0 to 0.143.0
---
Release: https://github.com/gohugoio/hugo/releases/tag/v0.143.0
Changelog: https://github.com/gohugoio/hugo/compare/v0.142.0...v0.143.0