### PR TITLE
chore(action): bump hugo from 0.146.3 to 0.146.6

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.146.3
+      HUGO_VERSION: 0.146.6
     steps:
       - name: Install Hugo CLI
         run: |


### PR DESCRIPTION
Bump [Hugo](https://github.com/gohugoio/hugo) from 0.146.3 to 0.146.6
---
Release: https://github.com/gohugoio/hugo/releases/tag/v0.146.6
Changelog: https://github.com/gohugoio/hugo/compare/v0.146.3...v0.146.6