### PR TITLE
chore(action): bump hugo from 0.147.5 to 0.147.7

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.147.5
+      HUGO_VERSION: 0.147.7
     steps:
       - name: Install Hugo CLI
         run: |


### PR DESCRIPTION
Bump [Hugo](https://github.com/gohugoio/hugo) from 0.147.5 to 0.147.7
---
Release: https://github.com/gohugoio/hugo/releases/tag/v0.147.7
Changelog: https://github.com/gohugoio/hugo/compare/v0.147.5...v0.147.7