### PR TITLE
chore(action): bump hugo from 0.149.1 to 0.150.0

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.149.1
+      HUGO_VERSION: 0.150.0
     steps:
       - name: Install Hugo CLI
         run: |


### PR DESCRIPTION
Bump [Hugo](https://github.com/gohugoio/hugo) from 0.149.1 to 0.150.0
---
Release: https://github.com/gohugoio/hugo/releases/tag/v0.150.0
Changelog: https://github.com/gohugoio/hugo/compare/v0.149.1...v0.150.0